### PR TITLE
Add CKAN benchmarking script

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,24 @@ Summary CSV files are produced each time the analysis runs in the [`data/out`](h
 - [trends by IT subcategory](https://github.com/goc-spending/contracts-data/tree/main/data/out/it_subcategories)
 - [trends by vendor](https://github.com/goc-spending/contracts-data/tree/main/data/out/vendors)
 
-A number of other analysis outputs are included in the overall trends folders, produced by [`research_findings.R`](https://github.com/goc-spending/contracts-data/blob/main/lib/research_findings.R) which is run automatically by `load.R`. 
+A number of other analysis outputs are included in the overall trends folders, produced by [`research_findings.R`](https://github.com/goc-spending/contracts-data/blob/main/lib/research_findings.R) which is run automatically by `load.R`.
+
+## Python scripts for quick benchmarking
+
+The `scripts` directory contains a minimal Python utility
+[`fetch_and_summarize.py`](scripts/fetch_and_summarize.py) that queries the
+Open Government CKAN API for contracts matching a keyword. It prints a short
+summary (average contract value and top vendors) and can optionally export the
+raw results to a CSV file. Install the dependencies listed in
+[`scripts/requirements.txt`](scripts/requirements.txt) and run the script like
+so:
+
+```bash
+python scripts/fetch_and_summarize.py "interpretation" --max-records 200 --output results.csv
+```
+
+Provincial data sources such as SEAO can be integrated in a similar way in the
+future.
 
 Charts for specific presentations and other artefacts are produced by [`additional_research_findings.R`](https://github.com/goc-spending/contracts-data/blob/main/analysis/research/additional_research_findings.R) and [`presentation_findings.R`](https://github.com/goc-spending/contracts-data/blob/main/analysis/research/presentation_findings.R), which need to be run separately after contract data has already loaded in the environment.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,30 @@
+# Scripts for Contract Data Benchmarking
+
+This directory contains utilities to fetch and summarize contract award data from
+Canada's open procurement portal. The primary entry point is
+`fetch_and_summarize.py`, which queries the CKAN API and outputs simple
+statistics.
+
+## Requirements
+- Python 3.8+
+- `requests` and `pandas`
+
+Install dependencies with:
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+```bash
+python fetch_and_summarize.py "interpretation" --max-records 200 --output results.csv
+```
+This command fetches up to 200 records matching the keyword "interpretation" and
+writes them to `results.csv`. A brief summary is printed to the console.
+
+Because the CKAN API contains hundreds of thousands of rows, consider adjusting
+`--max-records` depending on your bandwidth and required accuracy.
+
+## Limitations
+- Provincial data sources are not yet included; scraping those sites will
+  require additional code.
+- Network access is required to reach `open.canada.ca`.

--- a/scripts/fetch_and_summarize.py
+++ b/scripts/fetch_and_summarize.py
@@ -1,0 +1,77 @@
+import argparse
+import requests
+import pandas as pd
+from collections import Counter
+
+CKAN_API_ENDPOINT = "https://open.canada.ca/data/api/3/action/datastore_search"
+RESOURCE_ID = "fac950c0-00d5-4ec1-a4d3-9cbebf98a305"  # Proactive Disclosure of Contracts
+
+
+def fetch_page(keyword: str, offset: int = 0, limit: int = 100) -> dict:
+    """Fetch a single page of CKAN results."""
+    params = {
+        "resource_id": RESOURCE_ID,
+        "q": keyword,
+        "offset": offset,
+        "limit": limit,
+    }
+    resp = requests.get(CKAN_API_ENDPOINT, params=params, timeout=30)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def fetch_all(keyword: str, max_records: int = 500) -> list:
+    """Fetch up to max_records from the CKAN API."""
+    results = []
+    offset = 0
+    while offset < max_records:
+        page = fetch_page(keyword, offset=offset, limit=min(100, max_records - offset))
+        records = page.get("result", {}).get("records", [])
+        if not records:
+            break
+        results.extend(records)
+        offset += len(records)
+        if len(records) < 100:
+            break
+    return results
+
+
+def summarize(records: list) -> dict:
+    if not records:
+        return {}
+    df = pd.DataFrame(records)
+    df["contract_value"] = pd.to_numeric(df.get("contract_value", 0), errors="coerce")
+    avg_value = df["contract_value"].mean()
+    frequency = len(df)
+    top_vendors = Counter(df.get("vendor_name", []))
+    top_vendors = top_vendors.most_common(5)
+    return {
+        "average_value": avg_value,
+        "frequency": frequency,
+        "top_vendors": top_vendors,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Fetch and summarize contract data from CKAN")
+    parser.add_argument("keyword", help="Keyword to search for, e.g. 'interpretation'")
+    parser.add_argument("--max-records", type=int, default=500, help="Maximum number of records to fetch")
+    parser.add_argument("--output", help="Optional CSV output file")
+    args = parser.parse_args()
+
+    records = fetch_all(args.keyword, args.max_records)
+    if args.output:
+        pd.DataFrame(records).to_csv(args.output, index=False)
+    summary = summarize(records)
+    if summary:
+        print(f"Fetched {summary['frequency']} records")
+        print(f"Average contract value: {summary['average_value']:.2f}")
+        print("Top vendors:")
+        for vendor, count in summary['top_vendors']:
+            print(f"  {vendor}: {count}")
+    else:
+        print("No records found")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,2 @@
+requests
+pandas


### PR DESCRIPTION
## Summary
- add Python script to query the CKAN API and summarise contracts
- document usage in new `scripts` directory
- update README with instructions

## Testing
- `python -m py_compile scripts/fetch_and_summarize.py`

------
https://chatgpt.com/codex/tasks/task_e_6846488c7388832092b1283cc046ad5e